### PR TITLE
Only get temperature for devices that support it.

### DIFF
--- a/cli/broadlink_discovery
+++ b/cli/broadlink_discovery
@@ -19,7 +19,8 @@ for device in devices:
         print "# broadlink_cli --type 0x2712 --host {} --mac {}".format(device.host[0], ''.join(format(x, '02x') for x in device.mac))
         print "Device file data (to be used with --device @filename in broadlink_cli) : "
         print "0x2712 {} {}".format(device.host[0], ''.join(format(x, '02x') for x in device.mac))
-        print "temperature = {}".format(device.check_temperature())
+        if hasattr(device, 'check_temperature'):
+            print "temperature = {}".format(device.check_temperature())
         print ""
     else:
         print "Error authenticating with device : {}".format(device.host)


### PR DESCRIPTION
Calling check_temperature is only possible on the RM family of devices. The program used to crash if other types of devices were discovered (A1, MP1 etc.).